### PR TITLE
BUG: (cdea5bc) When loading a study resulted in closing of the desicos G...

### DIFF
--- a/desicos/abaqus/gui/testDB.py
+++ b/desicos/abaqus/gui/testDB.py
@@ -1136,7 +1136,6 @@ class TestDB(AFXDataDialog):
                     outpath))
             message(' ')
             form.loaded_study = True
-            self.update_database(True)
             os.chdir(outpath)
             return
 


### PR DESCRIPTION
...UI, the abaqus kernel would try to modify a non-existing GUI element and crash.

Bug fix for yesterday's commit cdea5bc.